### PR TITLE
Adding 1or0.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3732,9 +3732,9 @@ clubdash:
   - ttl: 600
     type: CNAME
     value: a.selfhosted.hackclub.com.
-
 1or0:
   - ttl: 600
     type: CNAME
-    value:  cname.vercel-dns.com.
+    value: 1or0.vercel.app.
+
 

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -410,6 +410,10 @@ _vercel:
     - vc-domain-verify=fhs.hackclub.com,46936764d6774efee2b5
     - vc-domain-verify=passport.hackclub.com,e2df763ae803aaf06728
     - vc-domain-verify=pfp.hackclub.com,0089a080527af2869592
+1or0:
+  - ttl: 3600
+    type: CNAME
+    value: 1or0.vercel.app.
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 600
   type: CNAME
@@ -3732,9 +3736,6 @@ clubdash:
   - ttl: 600
     type: CNAME
     value: a.selfhosted.hackclub.com.
-1or0:
-  - ttl: 600
-    type: CNAME
-    value: 1or0.vercel.app.
+
 
 

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -33,6 +33,11 @@
       - stripe-verification=5bdd0e2475b12744bfe1f778ac419f917800d476fd498ae2682ecd161d162c64
       - airtable-verification=6a190bbac6305fe1d58071f48f535cf5
       - yandex-verification=befd33a8f4f21226
+1or0:
+  - ttl: 3600
+    type: CNAME
+    value: 1or0.vercel.app.
+
 slashz:
   - ttl: 600
     type: CNAME
@@ -410,10 +415,6 @@ _vercel:
     - vc-domain-verify=fhs.hackclub.com,46936764d6774efee2b5
     - vc-domain-verify=passport.hackclub.com,e2df763ae803aaf06728
     - vc-domain-verify=pfp.hackclub.com,0089a080527af2869592
-1or0:
-  - ttl: 3600
-    type: CNAME
-    value: 1or0.vercel.app.
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 600
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3732,3 +3732,9 @@ clubdash:
   - ttl: 600
     type: CNAME
     value: a.selfhosted.hackclub.com.
+
+1or0:
+  - ttl: 600
+    type: CNAME
+    value:  cname.vercel-dns.com.
+


### PR DESCRIPTION
## Description

Adding the subdomain `1or0.hackclub.com` for our Hack Club's official website.

The domain points to `1or0.vercel.app`, which is our club site hosted on Vercel.  
Our club is called **1or0 Hack Club**, and this site will showcase what we’re building, updates, and useful resources for members.

Thanks for the awesome DNS system!
